### PR TITLE
Handle OSError when loading dotenv files

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -278,6 +278,8 @@ def load_dotenv_files(git_root, dotenv_fname, encoding="utf-8"):
             try:
                 load_dotenv(fname, override=True, encoding=encoding)
                 loaded.append(fname)
+            except OSError as e:
+                print(f"OSError loading {fname}: {e}")
             except Exception as e:
                 print(f"Error loading {fname}: {e}")
     return loaded


### PR DESCRIPTION
Add specific `OSError` handling to `load_dotenv_files` to provide more informative error messages for troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-51d8c468-9791-4893-87b9-1189b5342de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51d8c468-9791-4893-87b9-1189b5342de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

